### PR TITLE
Minor fix to allow build on non-Windows platforms

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -667,7 +667,8 @@ static void BenchCodeSize(const TestBase& test, const TestJsonList& testJsons, F
     int ret = spawnv(_P_WAIT, fullpath, argv);
 #else
     pid_t pid;
-    if (posix_spawn(&pid, fullpath, NULL, NULL, argv, NULL) == 0) {
+    int ret = posix_spawn(&pid, fullpath, NULL, NULL, argv, NULL);
+    if (ret == 0) {
         int status;
         waitpid(pid, &status, 0);
     }


### PR DESCRIPTION
Build fails on Linux with the following error:

```
main.cpp
../../src/main.cpp: In function ‘void BenchCodeSize(const TestBase&, const TestJsonList&, FILE*)’:
../../src/main.cpp:676:9: error: ‘ret’ was not declared in this scope
     if (ret != 0) {
```

See attached fix.
