### PR TITLE
Add RapidJSON AutoUTFInputStream test

### DIFF
--- a/src/tests/rapidjsonautoutftest.cpp
+++ b/src/tests/rapidjsonautoutftest.cpp
@@ -1,0 +1,41 @@
+#include "../test.h"
+
+// Turn on SSE2 for x86-64.
+#if defined(_M_X64) || defined(__amd64)
+#define RAPIDJSON_SSE2
+#endif
+
+#include "rapidjson/document.h"
+#include "rapidjson/encodedstream.h"
+#include "rapidjson/memorystream.h"
+
+using namespace rapidjson;
+
+class RapidjsonAutoUTFParseResult : public ParseResultBase {
+public:
+    Document document;
+};
+
+class RapidjsonAutoUTFTest : public TestBase {
+public:
+#if TEST_INFO
+    virtual const char* GetName() const { return "RapidJSON (C++, AutoUTF)"; }
+    virtual const char* GetFilename() const { return __FILE__; }
+#endif
+
+#if TEST_PARSE
+    virtual ParseResultBase* Parse(const char* json, size_t length) const {
+        MemoryStream ms(json, length);
+        RapidjsonAutoUTFParseResult* pr = new RapidjsonAutoUTFParseResult;
+        AutoUTFInputStream<unsigned, MemoryStream> is(ms);
+        if (pr->document.ParseStream<0, AutoUTF<unsigned> >(is).HasParseError()) {
+            delete pr;
+            return 0;
+        }
+        return pr;
+    }
+#endif
+
+};
+
+REGISTER_TEST(RapidjsonAutoUTFTest);


### PR DESCRIPTION
Adds a parsing test using RapidJSON `AutoUTFInputStream`, inspired by the thread at miloyip/rapidjson#159.

My results show (summarized):

```
Benchmarking RapidJSON (C++)
          Parse canada.json          ...  6.111 ms  351.296 MB/s
          Parse citm_catalog.json    ...  2.733 ms  602.704 MB/s
          Parse twitter.json         ...  2.023 ms  297.706 MB/s

Benchmarking RapidJSON (C++, AutoUTF)
          Parse canada.json          ... 10.171 ms  211.068 MB/s
          Parse citm_catalog.json    ...  7.745 ms  212.678 MB/s
          Parse twitter.json         ...  5.207 ms  115.663 MB/s
```

I'm not sure if this is something you want to add since you don't have variations on other libraries. However, I think it would be useful as a comparison and to use for possible future improvement of the `AutoUTF` approach.
