### PR TITLE
Fix taocpp/json info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Library | Language | Version | Notes
 [SimpleJSON](https://github.com/MJPA/SimpleJSON) | C++ | 
 [scheredom/json.h](https://github.com/sheredom/json.h) | C | | Not parsing number per se, so do it as post-process.
 udp/json | C | 1.1.0 | Actually 2 libraries: [udp/json-parser](https://github.com/udp/json-parser) & [udp/json-builder](https://github.com/udp/json-builder).
-[taocppjson](https://github.com/taocpp/json) | C++11 | 0.0.1
+[taocpp/json](https://github.com/taocpp/json) | C++11 | 1.0.0-beta.1 | Uses [PEGTL](https://github.com/ColinH/PEGTL) for parsing
 [ujson4c](https://github.com/esnme/ujson4c) | C | 
 [V8](https://github.com/v8/v8) | C++ | 4.8.271.17
 [vincenthz/libjson](https://github.com/vincenthz/libjson) | C | 0.8


### PR DESCRIPTION
Another small update to the taocpp/json information... From our side we feel that taocpp/json would be ready for inclusion in the graphs and charts in your main readme file, is there anything missing or preventing that where we can help? Thank you!