### PR TITLE
Use string_view in VoorheesTest::Parse.

### DIFF
--- a/src/tests/voorheestest.cpp
+++ b/src/tests/voorheestest.cpp
@@ -92,10 +92,9 @@ public:
 
 #if TEST_PARSE
     virtual ParseResultBase* Parse(const char* json, size_t length) const {
-        (void)length;
         VoorheesParseResult* pr = new VoorheesParseResult;
         try {
-            pr->root = parse(json);
+            pr->root = parse(string_view(json, length));
         }
         catch (...) {
             delete pr;


### PR DESCRIPTION
Don't just throw away the length parameter.