### PR TITLE
Fix compilation on OSX

### DIFF
--- a/build/premake.sh
+++ b/build/premake.sh
@@ -6,4 +6,6 @@ premake5 gmake
 #  https://github.com/miloyip/nativejson-benchmark/issues/25#issuecomment-174154308
 if [[ "$OSTYPE" == "darwin"* ]]; then
 	sed -i.bak 's/,-x//' gmake/*.make
+	sed -i.bak 's/-Wl,--start-group//' gmake/*.make
+	sed -i.bak 's/-Wl,--end-group//' gmake/*.make
 fi


### PR DESCRIPTION
llvm-c++ on OSX 10.11 doesn't seem to support `-Wl,--start-group` and `-Wl,--end-group`. I'm not sure how to get premake to stop generating this, so this was an easy hack to remove it.