### PR TITLE
update to newest sajson

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN buildDeps='build-essential gcc-multilib g++-multilib git-core curl ca-certif
 	&& git submodule update --init \
 	&& cd build \
 	&& curl -L -s https://github.com/premake/premake-core/releases/download/v5.0.0-alpha7/premake-5.0.0-alpha7-linux.tar.gz | tar -xvz \
-	&& chmod +x premake5 && chmod +x premake.sh && /bin/sh -c ./premake.sh && ./machine.sh \
+	&& chmod +x premake5 && chmod +x premake.sh && sync && /bin/sh -c ./premake.sh && ./machine.sh \
 	&& cd /nativejson-benchmark && make \
 	&& cd /nativejson-benchmark/bin \
 	&& for t in *; do ./$t; done \

--- a/src/tests/sajsontest.cpp
+++ b/src/tests/sajsontest.cpp
@@ -77,7 +77,7 @@ public:
 #if TEST_PARSE
     virtual ParseResultBase* Parse(const char* json, size_t length) const {
         (void)length;
-        SajsonParseResult* pr = new SajsonParseResult(parse(literal(json)));
+        SajsonParseResult* pr = new SajsonParseResult(parse(dynamic_allocation(), literal(json)));
         if (!pr->d.is_valid()) {
             //std::cout << "Error (" << pr->d.get_error_line() << ":" << pr->d.get_error_column() << "): " << pr->d.get_error_message() << std::endl;
             delete pr;
@@ -98,7 +98,7 @@ public:
 
 #if TEST_CONFORMANCE
     virtual bool ParseDouble(const char* json, double* d) const {
-        document doc = parse(literal(json));
+        document doc = parse(dynamic_allocation(), literal(json));
         if (doc.is_valid() &&
             doc.get_root().get_type() == TYPE_ARRAY &&
             doc.get_root().get_length() == 1 &&
@@ -112,7 +112,7 @@ public:
     }
 
     virtual bool ParseString(const char* json, std::string& s) const {
-        document doc = parse(literal(json));
+        document doc = parse(dynamic_allocation(), literal(json));
         if (doc.is_valid() &&
             doc.get_root().get_type() == TYPE_ARRAY &&
             doc.get_root().get_length() == 1 &&


### PR DESCRIPTION
Updates the benchmarks to the newest sajson, and switches to the dynamic allocation mode.  (Ideally we'd benchmark both sajson (single allocation) and sajson (dynamic allocation) in the suite but I wasn't sure how to set that up.)

Also fixes a weird docker bug calling premake on my Ubuntu 16.04 laptop.
