### PR TITLE
Add ThorsSerializer

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -127,4 +127,4 @@
 	url = https://github.com/boazsegev/facil.io.git
 [submodule "thirdparty/ThorsSerializer"]
 	path = thirdparty/ThorsSerializer
-	url = https://github.com/Loki-Astari/ThorsSerializer.git
+	url = git@github.com:Loki-Astari/ThorsSerializer.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -125,3 +125,6 @@
 [submodule "thirdparty/facil.io"]
 	path = thirdparty/facil.io
 	url = https://github.com/boazsegev/facil.io.git
+[submodule "thirdparty/ThorsSerializer"]
+	path = thirdparty/ThorsSerializer
+	url = https://github.com/Loki-Astari/ThorsSerializer.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,6 +79,9 @@ before_script:
   - ./configure --disable-shared
   - make
   - cd ${TRAVIS_BUILD_DIR}
+  - cd ${TRAVIS_BUILD_DIR}/thirdparty/ThorsSerializer
+  - ./configure --disable-binary --disable-yaml --disable-vera
+  - make install
 
 script:
   - make CONFIG=$CONFIG

--- a/src/jsonstat/jsonstatmain.cpp
+++ b/src/jsonstat/jsonstatmain.cpp
@@ -22,7 +22,7 @@ int main(int argc, char* argv[]) {
 	fclose(fp);
 
 	const TestBase& test = *TestManager::Instance().GetTests().front();
-    test.SetUp();
+    test.SetUp(argv[1]);
 
     ParseResultBase* dom = test.Parse(json, length);
     free(json);
@@ -31,7 +31,7 @@ int main(int argc, char* argv[]) {
     if (!test.Statistics(dom, &stat)) {
         printf("Not support Statistics\n");
         delete dom;
-        test.TearDown();
+        test.TearDown(argv[1]);
         return 3;
     }
 
@@ -48,6 +48,6 @@ int main(int argc, char* argv[]) {
     printf("elementCount: %10u\n", (unsigned)stat.elementCount);
     printf("stringLength: %10u\n", (unsigned)stat.stringLength);    
 
-    test.TearDown();
+    test.TearDown(argv[1]);
     return 0;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -206,12 +206,12 @@ static void Verify(const TestBase& test, const TestJsonList& testJsons) {
     for (TestJsonList::const_iterator itr = testJsons.begin(); itr != testJsons.end(); ++itr) {
         MEMORYSTAT_SCOPE();
 
-        test.SetUp();
+        test.SetUp(itr->fullpath);
         ParseResultBase* dom1 = test.Parse(itr->json, itr->length);
         if (!dom1) {
             printf("\nFailed to parse '%s'\n", itr->filename);
             failed = true;
-            test.TearDown();
+            test.TearDown(itr->fullpath);
             continue;
         }
 
@@ -219,7 +219,7 @@ static void Verify(const TestBase& test, const TestJsonList& testJsons) {
         if (!test.Statistics(dom1, &stat1)) {
             printf("Not support Statistics\n");
             delete dom1;
-            test.TearDown();
+            test.TearDown(itr->fullpath);
             continue;
         }
 
@@ -239,7 +239,7 @@ static void Verify(const TestBase& test, const TestJsonList& testJsons) {
                 printf("\n");
                 failed = true;
             }
-            test.TearDown();
+            test.TearDown(itr->fullpath);
             continue;
         }
 
@@ -257,7 +257,7 @@ static void Verify(const TestBase& test, const TestJsonList& testJsons) {
             fclose(fp);
 
             delete json1;
-            test.TearDown();
+            test.TearDown(itr->fullpath);
             continue;
         }
 
@@ -303,7 +303,7 @@ static void Verify(const TestBase& test, const TestJsonList& testJsons) {
 
         delete json1;
         delete json2;
-        test.TearDown();
+        test.TearDown(itr->fullpath);
 
         MEMORYSTAT_CHECKMEMORYLEAK();
     }
@@ -366,7 +366,7 @@ static void BenchParse(const TestBase& test, const TestJsonList& testJsons, FILE
         BENCH_MEMORYSTAT_INIT();
         bool supported = true;
         for (unsigned trial = 0; trial < cTrialCount; trial++) {
-            test.SetUp();
+            test.SetUp(itr->fullpath);
             Timer timer;
             ParseResultBase* dom;
             {
@@ -383,13 +383,13 @@ static void BenchParse(const TestBase& test, const TestJsonList& testJsons, FILE
 
             if (!dom) {
                 supported = false;
-                test.TearDown();
+                test.TearDown(itr->fullpath);
                 break;
             }
 
             double duration = timer.GetElapsedMilliseconds();
             minDuration = std::min(minDuration, duration);
-            test.TearDown();
+            test.TearDown(itr->fullpath);
         }
 
         if (!supported)
@@ -418,7 +418,7 @@ static void BenchStringify(const TestBase& test, const TestJsonList& testJsons, 
         printf("%15s %-20s ... ", "Stringify", itr->filename);
         fflush(stdout);
 
-        test.SetUp();
+        test.SetUp(itr->fullpath);
         double minDuration = DBL_MAX;
         ParseResultBase* dom = test.Parse(itr->json, itr->length);
 
@@ -449,7 +449,7 @@ static void BenchStringify(const TestBase& test, const TestJsonList& testJsons, 
         }
 
         delete dom;
-        test.TearDown();
+        test.TearDown(itr->fullpath);
 
         if (!supported)
             printf("Not support\n");
@@ -477,7 +477,7 @@ static void BenchPrettify(const TestBase& test, const TestJsonList& testJsons, F
         printf("%15s %-20s ... ", "Prettify", itr->filename);
         fflush(stdout);
 
-        test.SetUp();
+        test.SetUp(itr->fullpath);
         double minDuration = DBL_MAX;
         ParseResultBase* dom = test.Parse(itr->json, itr->length);
 
@@ -508,7 +508,7 @@ static void BenchPrettify(const TestBase& test, const TestJsonList& testJsons, F
         }
 
         delete dom;
-        test.TearDown();
+        test.TearDown(itr->fullpath);
 
         if (!supported)
             printf("Not support\n");
@@ -536,7 +536,7 @@ static void BenchStatistics(const TestBase& test, const TestJsonList& testJsons,
         printf("%15s %-20s ... ", "Statistics", itr->filename);
         fflush(stdout);
 
-        test.SetUp();
+        test.SetUp(itr->fullpath);
         double minDuration = DBL_MAX;
         ParseResultBase* dom = test.Parse(itr->json, itr->length);
 
@@ -563,7 +563,7 @@ static void BenchStatistics(const TestBase& test, const TestJsonList& testJsons,
         }
 
         delete dom;
-        test.TearDown();
+        test.TearDown(itr->fullpath);
 
         if (!supported)
             printf("Not support\n");
@@ -596,7 +596,7 @@ static void BenchSaxRoundtrip(const TestBase& test, const TestJsonList& testJson
         BENCH_MEMORYSTAT_INIT();
         bool supported = true;
         for (unsigned trial = 0; trial < cTrialCount; trial++) {
-            test.SetUp();
+            test.SetUp(itr->fullpath);
             Timer timer;
             StringResultBase* json;
             {
@@ -613,13 +613,13 @@ static void BenchSaxRoundtrip(const TestBase& test, const TestJsonList& testJson
 
             if (!json) {
                 supported = false;
-                test.TearDown();
+                test.TearDown(itr->fullpath);
                 break;
             }
 
             double duration = timer.GetElapsedMilliseconds();
             minDuration = std::min(minDuration, duration);
-            test.TearDown();
+            test.TearDown(itr->fullpath);
         }
 
         if (!supported)
@@ -653,7 +653,7 @@ static void BenchSaxStatistics(const TestBase& test, const TestJsonList& testJso
         BENCH_MEMORYSTAT_INIT();
         bool supported = true;
         for (unsigned trial = 0; trial < cTrialCount; trial++) {
-            test.SetUp();
+            test.SetUp(itr->fullpath);
             Timer timer;
             {
                 MEMORYSTAT_SCOPE();
@@ -667,13 +667,13 @@ static void BenchSaxStatistics(const TestBase& test, const TestJsonList& testJso
             }
 
             if (!supported) {
-                test.TearDown();
+                test.TearDown(itr->fullpath);
                 break;
             }
 
             double duration = timer.GetElapsedMilliseconds();
             minDuration = std::min(minDuration, duration);
-            test.TearDown();
+            test.TearDown(itr->fullpath);
         }
 
         if (!supported)
@@ -839,13 +839,13 @@ static void BenchConformance(const TestBase& test, FILE* fp) {
         if (!json)
             continue;
 
-        test.SetUp();
+        test.SetUp(path);
         ParseResultBase* pr = test.Parse(json, length);
         bool result = pr != 0;
         fprintf(fp, "1. Parse Validation,%s,pass%02d,%s\n", test.GetName(), i, result ? "true" : "false");
         // printf("pass%02d: %s\n", i, result ? "true" : "false");
         delete pr;
-        test.TearDown();
+        test.TearDown(path);
 
         if (!result) {
             if (md)
@@ -871,13 +871,13 @@ static void BenchConformance(const TestBase& test, FILE* fp) {
         if (!json)
             continue;
 
-        test.SetUp();
+        test.SetUp(path);
         ParseResultBase* pr = test.Parse(json, length);
         bool result = pr == 0;
         fprintf(fp, "1. Parse Validation,%s,fail%02d,%s\n", test.GetName(), i, result ? "true" : "false");
         // printf("fail%02d: %s\n", i, result ? "true" : "false");
         delete pr;
-        test.TearDown();
+        test.TearDown(path);
 
         if (!result) {
             if (md)
@@ -911,7 +911,7 @@ static void BenchConformance(const TestBase& test, FILE* fp) {
         {\
             bool result = false;\
             double actual = 0.0;\
-            test.SetUp();\
+            test.SetUp("vector-double");\
             if (test.ParseDouble(json, &actual)) \
                 result = Double(expect).Uint64Value() == Double(actual).Uint64Value();\
             if (!result) {\
@@ -926,7 +926,7 @@ static void BenchConformance(const TestBase& test, FILE* fp) {
             /*if (!result)*/\
             /*    printf("JSON: %s\nExpect: %17g\nActual: %17g\n\n", json, expect, actual);*/\
             fprintf(fp, "2. Parse Double,%s,double%02d,%s\n", test.GetName(), i, result ? "true" : "false");\
-            test.TearDown();\
+            test.TearDown("vector-double");\
             i++;\
         }
         TEST_DOUBLE("[0.0]", 0.0);
@@ -1058,7 +1058,7 @@ static void BenchConformance(const TestBase& test, FILE* fp) {
             bool result = false;\
             size_t expectLength = sizeof(expect) - 1;\
             std::string actual;\
-            test.SetUp();\
+            test.SetUp("vector-string");\
             if (test.ParseString(json, actual)) \
                 result = (expectLength == actual.size()) && (memcmp(expect, actual.c_str(), expectLength) == 0);\
             if (!result) {\
@@ -1077,7 +1077,7 @@ static void BenchConformance(const TestBase& test, FILE* fp) {
             /*if (!result)*/\
             /*    printf("JSON: %s\nExpect: %s (%u) \nActual: %s (%u)\n\n", json, expect, (unsigned)expectLength, actual.c_str(), (unsigned)actual.size());*/\
             fprintf(fp, "3. Parse String,%s,string%02d,%s\n", test.GetName(), i, result ? "true" : "false");\
-            test.TearDown();\
+            test.TearDown("vector-string");\
             i++;\
         }
 
@@ -1113,7 +1113,7 @@ static void BenchConformance(const TestBase& test, FILE* fp) {
         if (!json)
             continue;
 
-        test.SetUp();
+        test.SetUp(path);
         ParseResultBase* pr = test.Parse(json, length);
         bool result = false;
         bool terminate = false;
@@ -1152,7 +1152,7 @@ static void BenchConformance(const TestBase& test, FILE* fp) {
                 terminate = true; // This library does not support stringify, terminate this test
         }
 
-        test.TearDown();
+        test.TearDown(path);
         free(json);
 
         if (terminate)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1208,6 +1208,7 @@ int main(int argc, char* argv[]) {
     bool doVerify = true;
     bool doPerformance = true;
     bool doConformance = true;
+    std::string parserName;
 
     if (argc == 2) {
         if (strcmp(argv[1], "--verify-only") == 0) {
@@ -1221,6 +1222,9 @@ int main(int argc, char* argv[]) {
         else if (strcmp(argv[1], "--conformance-only") == 0) {
             doConformance = true;
             doVerify = doPerformance = false;
+        }
+        else if (strncmp(argv[1], "--parser=", 9) == 0) {
+            parserName = argv[1] + 9;
         }
         else {
             fprintf(stderr, "Invalid option\n");
@@ -1240,6 +1244,27 @@ int main(int argc, char* argv[]) {
 
         // sort tests
         TestList& tests = TestManager::Instance().GetTests();
+
+        // See if we want to use only one test.
+        if (parserName != "") {
+            bool foundParser = false;
+            for(TestBase const* item: tests) {
+                if (parserName == item->GetName()) {
+                    tests.clear();
+                    tests.push_back(item);
+                    foundParser = true;
+                    break;
+                }
+            }
+            if (!foundParser) {
+                fprintf(stderr, "Unknown Parser : %s\n", parserName.c_str());
+                for(TestBase const* item: tests) {
+                    fprintf(stderr, "\t%s\n", item->GetName());
+                }
+                exit(1);
+            }
+        }
+
         std::sort(tests.begin(), tests.end());
 
         if (doVerify)

--- a/src/test.h
+++ b/src/test.h
@@ -123,6 +123,12 @@ public:
     // It is mainly for libraries require huge initialize time (e.g. Creating Isolate in V8).
     virtual void SetUp() const {}
     virtual void TearDown() const {}
+    // Some parsers need more information for setup.
+    // Pass in the name of the test. The default action
+    // Is to call the original SetUp() method to maintain
+    // backwards compatability.
+    virtual void SetUp(char const*)     const {SetUp();}
+    virtual void TearDown(char const*)  const {TearDown();}
 
 #if TEST_INFO
     virtual const char* GetName() const = 0;

--- a/src/tests/ThorsSerializer.cpp
+++ b/src/tests/ThorsSerializer.cpp
@@ -1,0 +1,206 @@
+#include "../test.h"
+
+#include "ThorsSerializer_StringNumber.h"
+#include "ThorsSerializer_GetStats.h"
+#include "ThorsSerializer_Twitter.h"
+#include "ThorsSerializer_Canada.h"
+#include "ThorsSerializer_citm_catalog.h"
+
+#include "ThorSerialize/Traits.h"
+#include "ThorSerialize/JsonThor.h"
+#include "ThorSerialize/SerUtil.h"
+#include <iostream>
+#include <map>
+#include <memory>
+#include "ThorsSerializer_Common.h"
+
+class ThorsSerializerTest: public TestBase
+{
+    TestAction                                   testNotImplemented;
+    VectorDouble                                 testVectorDouble;
+    VectorString                                 testVectorString;
+    GetValue<std::map<std::string, std::string>> testGetValueMap2String;
+    GetValue<std::map<std::string, bool>>        testGetValueMap2Bool;
+    GetValue<std::map<std::string, int>>         testGetValueMap2Int;
+    GetValue<std::map<std::string, int*>>        testGetValueMap2IntPointer;
+    GetValue<std::map<std::string, M01>>         testGetValueMap2M01;
+    GetValue<std::vector<std::string>>           testGetValueVec2String;
+    //GetValue<std::vector<L18>>                   testGetValueVec2L18;
+    GetValue<std::vector<int*>>                  testGetValueVec2IntPointer;
+    GetValue<std::vector<bool>>                  testGetValueVec2Bool;
+    GetValue<std::vector<int>>                   testGetValueVec2Int;
+    GetValue<std::vector<long>>                  testGetValueVec2Long;
+    GetValue<std::vector<double>>                testGetValueVec2Double;
+    GetValue<std::vector<StringNumber>>          testGetValueVec2StringNumber;
+    GetValue<Obj2>                               testGetValueObj2;
+    GetValue<Obj3>                               testGetValueObj3;
+    GetValue<Country>                            testGetValueCountry;
+    GetValue<Perform>                            testGetValuePerform;
+    GetValue<Twitter>                            testGetValueTwitter;
+
+    ActionMap                   actionMap;
+    mutable TestAction const*   currentRunner;
+
+    public:
+    ThorsSerializerTest()
+    {
+        actionMap["vector-double"]                      = &testVectorDouble;
+        actionMap["vector-string"]                      = &testVectorString;
+
+        actionMap["../data/canada.json"]                = &testGetValueCountry;
+        actionMap["../data/citm_catalog.json"]          = &testGetValuePerform;
+        actionMap["../data/twitter.json"]               = &testGetValueTwitter;
+
+        actionMap["../data/jsonchecker/fail02.json"]    = &testGetValueVec2String;
+        actionMap["../data/jsonchecker/fail03.json"]    = &testGetValueMap2String;
+        actionMap["../data/jsonchecker/fail04.json"]    = &testGetValueVec2String;
+        actionMap["../data/jsonchecker/fail05.json"]    = &testGetValueVec2String;
+        actionMap["../data/jsonchecker/fail06.json"]    = &testGetValueVec2String;
+        actionMap["../data/jsonchecker/fail07.json"]    = &testGetValueVec2String;
+        actionMap["../data/jsonchecker/fail08.json"]    = &testGetValueVec2String;
+        actionMap["../data/jsonchecker/fail09.json"]    = &testGetValueMap2Bool;
+        actionMap["../data/jsonchecker/fail10.json"]    = &testGetValueMap2Bool;
+        actionMap["../data/jsonchecker/fail11.json"]    = &testGetValueMap2Int;
+        actionMap["../data/jsonchecker/fail12.json"]    = &testGetValueMap2String;
+        actionMap["../data/jsonchecker/fail13.json"]    = &testGetValueMap2Int;
+        actionMap["../data/jsonchecker/fail14.json"]    = &testGetValueMap2Int;
+        actionMap["../data/jsonchecker/fail15.json"]    = &testGetValueVec2String;
+        actionMap["../data/jsonchecker/fail16.json"]    = &testGetValueVec2String;
+        actionMap["../data/jsonchecker/fail17.json"]    = &testGetValueVec2String;
+
+        actionMap["../data/jsonchecker/fail19.json"]    = &testGetValueMap2IntPointer;
+        actionMap["../data/jsonchecker/fail20.json"]    = &testGetValueMap2IntPointer;
+        actionMap["../data/jsonchecker/fail21.json"]    = &testGetValueMap2IntPointer;
+        actionMap["../data/jsonchecker/fail22.json"]    = &testGetValueVec2String;
+        actionMap["../data/jsonchecker/fail23.json"]    = &testGetValueVec2String;
+        actionMap["../data/jsonchecker/fail24.json"]    = &testGetValueVec2String;
+        actionMap["../data/jsonchecker/fail25.json"]    = &testGetValueVec2String;
+        actionMap["../data/jsonchecker/fail26.json"]    = &testGetValueVec2String;
+        actionMap["../data/jsonchecker/fail27.json"]    = &testGetValueVec2String;
+        actionMap["../data/jsonchecker/fail28.json"]    = &testGetValueVec2String;
+        actionMap["../data/jsonchecker/fail29.json"]    = &testGetValueVec2Double;
+        actionMap["../data/jsonchecker/fail30.json"]    = &testGetValueVec2Double;
+        actionMap["../data/jsonchecker/fail31.json"]    = &testGetValueVec2Double;
+        actionMap["../data/jsonchecker/fail32.json"]    = &testGetValueMap2Bool;
+        actionMap["../data/jsonchecker/fail33.json"]    = &testGetValueVec2String;
+
+        //  pass01.json     ThorsSerializer does not support polymorphic arrays
+        //actionMap["../data/jsonchecker/pass02.json"]    = &testGetValueVec2L18;
+        actionMap["../data/jsonchecker/pass03.json"]    = &testGetValueMap2M01;
+
+
+        actionMap["../data/roundtrip/roundtrip01.json"] = &testGetValueVec2IntPointer;
+        actionMap["../data/roundtrip/roundtrip02.json"] = &testGetValueVec2Bool;
+        actionMap["../data/roundtrip/roundtrip03.json"] = &testGetValueVec2Bool;
+        actionMap["../data/roundtrip/roundtrip04.json"] = &testGetValueVec2Int;
+        actionMap["../data/roundtrip/roundtrip05.json"] = &testGetValueVec2String;
+        actionMap["../data/roundtrip/roundtrip06.json"] = &testGetValueVec2Int;
+        actionMap["../data/roundtrip/roundtrip07.json"] = &testGetValueMap2String;
+        actionMap["../data/roundtrip/roundtrip08.json"] = &testGetValueVec2Int;
+        actionMap["../data/roundtrip/roundtrip09.json"] = &testGetValueObj2;
+        actionMap["../data/roundtrip/roundtrip10.json"] = &testGetValueObj3;
+        actionMap["../data/roundtrip/roundtrip11.json"] = &testGetValueVec2Int;
+        actionMap["../data/roundtrip/roundtrip12.json"] = &testGetValueVec2Int;
+        actionMap["../data/roundtrip/roundtrip13.json"] = &testGetValueVec2Long;
+        actionMap["../data/roundtrip/roundtrip14.json"] = &testGetValueVec2Long;
+        actionMap["../data/roundtrip/roundtrip15.json"] = &testGetValueVec2Int;
+        actionMap["../data/roundtrip/roundtrip16.json"] = &testGetValueVec2Int;
+        actionMap["../data/roundtrip/roundtrip17.json"] = &testGetValueVec2Long;
+        actionMap["../data/roundtrip/roundtrip18.json"] = &testGetValueVec2Long;
+        actionMap["../data/roundtrip/roundtrip19.json"] = &testGetValueVec2Long;
+        actionMap["../data/roundtrip/roundtrip20.json"] = &testGetValueVec2Double;
+        actionMap["../data/roundtrip/roundtrip21.json"] = &testGetValueVec2StringNumber;
+        actionMap["../data/roundtrip/roundtrip22.json"] = &testGetValueVec2StringNumber;
+        actionMap["../data/roundtrip/roundtrip23.json"] = &testGetValueVec2StringNumber;
+        actionMap["../data/roundtrip/roundtrip24.json"] = &testGetValueVec2StringNumber;
+        actionMap["../data/roundtrip/roundtrip25.json"] = &testGetValueVec2StringNumber;
+        actionMap["../data/roundtrip/roundtrip26.json"] = &testGetValueVec2StringNumber;
+        actionMap["../data/roundtrip/roundtrip27.json"] = &testGetValueVec2StringNumber;
+
+        currentRunner      = &testNotImplemented;
+    }
+    virtual void SetUp(char const* fullPath) const
+    {
+        // std::cout << "Test: " << fullPath << " : " << fileName << "\n";
+
+        auto find = actionMap.find(fullPath);
+        if (find != actionMap.end())
+        {
+            currentRunner   = find->second;
+        }
+    }
+    virtual void TearDown(char const*) const
+    {
+        currentRunner = &testNotImplemented;
+    }
+
+#if TEST_INFO
+    virtual const char* GetName() const /*override*/        { return "ThorsSerializer"; }
+    virtual const char* GetFilename() const /*override*/    { return __FILE__; }
+#endif
+#if TEST_PARSE
+    virtual ParseResultBase* Parse(const char* json, size_t length) const {
+        return currentRunner->Parse(json, length);
+    }
+#endif
+#if TEST_CONFORMANCE
+    virtual bool ParseDouble(const char* json, double* d) const {
+        return currentRunner->ParseDouble(json, d);
+    }
+
+    virtual bool ParseString(const char* json, std::string& s) const {
+        return currentRunner->ParseString(json, s);
+    }
+#endif
+#if TEST_SAXROUNDTRIP
+    virtual StringResultBase* SaxRoundtrip(const char*, size_t) const {
+        return nullptr;
+    }
+#endif
+
+
+#if TEST_STRINGIFY
+    virtual StringResultBase* Stringify(const ParseResultBase* parseResult) const {
+        return currentRunner->Stringify(parseResult);
+    }
+#endif
+
+#if TEST_PRETTIFY
+    virtual StringResultBase* Prettify(const ParseResultBase* parseResult) const {
+        return currentRunner->Prettify(parseResult);
+    }
+#endif
+
+#if TEST_STATISTICS
+    virtual bool Statistics(const ParseResultBase* parseResult, Stat* stat) const {
+        stat->objectCount   = 0;
+        stat->arrayCount    = 0;
+        stat->numberCount   = 0;
+        stat->stringCount   = 0;
+        stat->trueCount     = 0;
+        stat->falseCount    = 0;
+        stat->nullCount     = 0;
+
+        stat->memberCount   = 0;
+        stat->elementCount  = 0;
+        stat->stringLength  = 0;
+
+        return currentRunner->Statistics(parseResult, stat);
+    }
+#endif
+
+#if TEST_SAXSTATISTICS
+    virtual bool SaxStatistics(const char*, size_t, Stat*) const {
+        return false;
+    }
+#endif
+
+#if TEST_SAXSTATISTICSUTF16
+    virtual bool SaxStatisticsUTF16(const char*, size_t, Stat*) const {
+        return false;
+    }
+#endif
+};
+
+REGISTER_TEST(ThorsSerializerTest);
+

--- a/src/tests/ThorsSerializer_Canada.h
+++ b/src/tests/ThorsSerializer_Canada.h
@@ -1,0 +1,126 @@
+#ifndef THORS_SERIALIZER_CANADA_H
+#define THORS_SERIALIZER_CANADA_H
+
+#include "ThorSerialize/Traits.h"
+#include "ThorSerialize/SerUtil.h"
+#include <vector>
+#include <string>
+
+struct Properties
+{
+    std::string     name;
+};
+ThorsAnvil_MakeTrait(Properties, name);
+inline void getStats(Stat* stat, Properties const& value)
+{
+    stat->objectCount++;
+    stat->memberCount++;
+    stat->stringCount += 2;
+    stat->stringLength += (4 /*name*/ + value.name.size());
+}
+
+struct Cord
+{
+    std::pair<double, double>       value;
+    using value_type = double;
+    std::size_t size() const {return 2;}
+};
+inline void getStats(Stat* stat, Cord const&)
+{
+    stat->arrayCount++;
+    stat->elementCount += 2;
+    stat->numberCount += 2;
+}
+
+namespace ThorsAnvil
+{
+    namespace Serialize
+    {
+template<>
+class ContainerMemberExtractorEmplacer<Cord>
+{
+    public:
+        constexpr ContainerMemberExtractorEmplacer() {}
+        constexpr std::size_t getHash(std::size_t start) const
+        {
+            return 0x4567 | start;
+        }
+        void operator()(PrinterInterface& printer, Cord const& object) const
+        {
+            PutValueType<double>     valuePutter(printer);
+            valuePutter.putValue(object.value.first);
+            valuePutter.putValue(object.value.second);
+        }
+        void operator()(ParserInterface& parser, std::size_t const& index, Cord& object) const
+        {
+            GetValueType<double>   valueGetter(parser, index == 0 ? object.value.first : object.value.second);
+        }
+};
+template<>
+class Traits<Cord>
+{
+    public:
+        static constexpr TraitType type = TraitType::Array;
+        typedef ContainerMemberExtractorEmplacer<Cord>    MemberExtractor;
+        static MemberExtractor const& getMembers()
+        {
+            static constexpr MemberExtractor    memberExtractor;
+            return memberExtractor;
+        }
+};
+
+    }
+}
+
+using   CordVec = std::vector<Cord>;
+using   CordMat = std::vector<CordVec>;
+
+struct Geometry
+{
+    std::string     type;
+    CordMat         coordinates;
+};
+ThorsAnvil_MakeTrait(Geometry, type, coordinates);
+inline void getStats(Stat* stat, Geometry const& value)
+{
+    stat->objectCount++;
+    stat->memberCount += 2;
+    stat->stringCount += 3; /* Key + Key + Value*/
+    stat->stringLength += (4 /*type*/ + 11 /*coordinates*/ + value.type.size());
+    getStats(stat, value.coordinates);
+}
+
+struct Feature
+{
+    std::string     type;
+    Properties      properties;
+    Geometry        geometry;
+};
+ThorsAnvil_MakeTrait(Feature, type, properties, geometry);
+inline void getStats(Stat* stat, Feature const& value)
+{
+    stat->objectCount++;
+    stat->memberCount   += 3;
+    stat->stringCount   += 4; /* Key + Key + Key + Value */
+    stat->stringLength  += (4 /*type*/ + 10 /*properties*/ + 8 /*geometry*/ + value.type.size());
+    getStats(stat, value.properties);
+    getStats(stat, value.geometry);
+}
+using Features  = std::vector<Feature>;
+
+struct Country
+{
+    std::string     type;
+    Features        features;
+};
+ThorsAnvil_MakeTrait(Country, type, features);
+inline void getStats(Stat* stat, Country const& value)
+{
+    stat->objectCount++;
+    stat->memberCount+=2;
+    stat->stringCount += 3; /*Key + Key + Value */
+    stat->stringLength += (4 /*types*/ + 8 /*features*/ + value.type.size());
+    getStats(stat, value.features);
+}
+
+#endif

--- a/src/tests/ThorsSerializer_Common.h
+++ b/src/tests/ThorsSerializer_Common.h
@@ -1,0 +1,203 @@
+#ifndef THORS_SERIALIZER_COMMON_H
+#define THORS_SERIALIZER_COMMON_H
+
+class TestAction
+{
+    public:
+    virtual ParseResultBase* Parse(const char*, size_t) const {
+        return nullptr;
+    }
+    virtual bool ParseDouble(const char*, double*) const {
+        return false;
+    }
+    virtual bool ParseString(const char*, std::string&) const {
+        return false;
+    }
+    virtual StringResultBase* SaxRoundtrip(const char*, size_t) const {
+        return nullptr;
+    }
+    virtual StringResultBase* Stringify(const ParseResultBase*) const {
+        return nullptr;
+    }
+    virtual StringResultBase* Prettify(const ParseResultBase*) const {
+        return nullptr;
+    }
+    virtual bool Statistics(const ParseResultBase*, Stat*) const {
+        return false;
+    }
+};
+
+using ThorsAnvil::Serialize::jsonExport;
+using ThorsAnvil::Serialize::jsonImport;
+using ThorsAnvil::Serialize::ParserInterface;
+using ThorsAnvil::Serialize::PrinterInterface;
+
+class VectorDouble: public TestAction
+{
+    public:
+    virtual bool ParseDouble(const char* json, double* d) const {
+        std::stringstream stream(json);
+        std::vector<double> result;
+        stream >> jsonImport(result, ParserInterface::ParseType::Weak, true);
+        if (stream && result.size() == 1) {
+            *d = result[0];
+            return true;
+        }
+        return false;
+    }
+};
+class VectorString: public TestAction
+{
+    public:
+    virtual bool ParseString(const char* json, std::string& output) const {
+        std::stringstream stream(json);
+        std::vector<std::string> result;
+        stream >> jsonImport(result, ParserInterface::ParseType::Weak, true);
+        if (stream && result.size() == 1) {
+            output = result[0];
+            return true;
+        }
+        return false;
+    }
+};
+
+
+template<typename Value>
+struct GetValueResult: public ParseResultBase
+{
+    Value       data;
+    GetValueResult()
+        : data{}
+    {}
+};
+struct GetValueStream: public StringResultBase {
+    std::stringstream   stream;
+    virtual const char* c_str() const   {return stream.str().c_str();}
+};
+
+class CStringStream: public std::istream
+{
+    class CStringStreamBuf: public std::streambuf
+    {
+        public:
+            CStringStreamBuf(char const* buffer, std::size_t len)
+            {
+                // This is safe as long as it is only used
+                // as part of an istream (read only).
+                // That is why I have wrapped this inside a class that only
+                // inherits from std::istream.
+                //
+                // Any put back operations don't write to the buffer.
+                // They validate they are putting back the same character
+                // that is in the buffer and if not call pbackfail()
+                // By default the pbackfail() fails returning EOF.
+                // This is fine for our use case.
+                char* b = const_cast<char*>(buffer);
+                setg(b, b, b+ len);
+            }
+    };
+    CStringStreamBuf    streamBuf;;
+    public:
+        CStringStream(char const* buffer, std::size_t len)
+            // This is technically unsafe as the streamBuf has not been
+            // initialized. But the istream constructor does not use
+            // the buffer, only stores the pointer for later use.
+            // So this will work as expected.
+            : std::istream(&streamBuf)
+            , streamBuf(buffer, len)
+        {}
+};
+
+template<typename Value>
+class GetValue: public TestAction
+{
+    public:
+    virtual ParseResultBase* Parse(const char* json, size_t len) const {
+        GetValueResult<Value>* result = new GetValueResult<Value>();
+        CStringStream        stream(json, len);
+        stream >> jsonImport(result->data, ParserInterface::ParseType::Weak, true);
+        char bad;
+        if (!stream || stream >> bad) {
+            delete result;
+            result = nullptr;
+        }
+        return result;
+    }
+    virtual StringResultBase* Stringify(ParseResultBase const* value) const {
+        GetValueStream* result = new GetValueStream;
+        GetValueResult<Value> const* inputValue = dynamic_cast<GetValueResult<Value> const*>(value);
+        result->stream << jsonExport(inputValue->data, PrinterInterface::OutputType::Stream, true);
+        return result;
+    }
+    virtual StringResultBase* Prettify(const ParseResultBase* value) const {
+        GetValueStream* result = new GetValueStream;
+        GetValueResult<Value> const* inputValue = dynamic_cast<GetValueResult<Value> const*>(value);
+        result->stream << jsonExport(inputValue->data, PrinterInterface::OutputType::Config, true);
+        return result;
+    }
+    virtual bool Statistics(const ParseResultBase* value, Stat* stat) const {
+        GetValueResult<Value> const* inputValue = dynamic_cast<GetValueResult<Value> const*>(value);
+        getStats(stat, inputValue->data);
+        return true;
+    }
+};
+
+using ActionMap = std::map<std::string, TestAction*>;
+using   L01= std::vector<std::string>;
+using   L02= std::vector<L01>;
+using   L03= std::vector<L02>;
+using   L04= std::vector<L03>;
+using   L05= std::vector<L04>;
+using   L06= std::vector<L05>;
+using   L07= std::vector<L06>;
+using   L08= std::vector<L07>;
+using   L09= std::vector<L08>;
+using   L10= std::vector<L09>;
+using   L11= std::vector<L10>;
+using   L12= std::vector<L11>;
+using   L13= std::vector<L12>;
+using   L14= std::vector<L13>;
+using   L15= std::vector<L14>;
+using   L16= std::vector<L15>;
+using   L17= std::vector<L16>;
+using   L18= std::vector<L17>;
+using   M01= std::map<std::string, std::string>;
+inline void getStats(Stat* stat, std::map<std::string, M01> const& value)
+{
+    stat->objectCount++;
+    stat->memberCount += value.size();
+    for(auto const& da: value) {
+        stat->stringLength += da.first.size();
+        getStats(stat, da.second);
+    }
+}
+
+struct Obj2
+{
+    std::string     foo;
+};
+ThorsAnvil_MakeTrait(Obj2, foo);
+inline void getStats(Stat* stat, Obj2 const& value)
+{
+    stat->objectCount++;
+    stat->elementCount++;
+    stat->stringCount += 2; /* Key + Value */
+    stat->stringLength += (3 /*foo*/ + value.foo.size());
+}
+
+struct Obj3
+{
+    Opt<int>        a;
+    std::string     foo;
+};
+ThorsAnvil_MakeTrait(Obj3, a, foo);
+inline void getStats(Stat* stat, Obj3 const& value)
+{
+    stat->objectCount++;
+    stat->elementCount += 2;
+    ((value.a) ? stat->numberCount : stat->nullCount)++;
+    stat->stringCount += 3; /*Key + Key + Value*/
+    stat->stringLength += (3 /*foo*/ + 1 /*a*/ + value.foo.size());
+}
+
+#endif

--- a/src/tests/ThorsSerializer_GetStats.h
+++ b/src/tests/ThorsSerializer_GetStats.h
@@ -1,0 +1,64 @@
+#ifndef THORS_SERIALIZER_GET_STATS_H
+#define THORS_SERIALIZER_GET_STATS_H
+
+#include <map>
+#include <vector>
+#include <string>
+
+template<typename T>
+inline void getStats(Stat* stat, std::unique_ptr<T> const& value)
+{
+    if (!value) {
+        stat->nullCount++;
+        return;
+    }
+    getStats(stat, *value);
+}
+template<typename T>
+inline void getStatsMayNotExist(Stat* stat, std::unique_ptr<T> const& value, std::size_t keySize)
+{
+    if (value) {
+        stat->memberCount++;
+        stat->stringCount++;
+        stat->stringLength += keySize;
+        getStats(stat, *value);
+    }
+}
+
+inline void getStats(Stat* stat, int const&) { stat->numberCount++; }
+inline void getStats(Stat* stat, long const&) { stat->numberCount++; }
+inline void getStats(Stat* stat, double const&) { stat->numberCount++; }
+inline void getStats(Stat* stat, bool const& value)
+{
+    (value ? stat->trueCount : stat->falseCount)++;
+}
+inline void getStats(Stat* stat, std::string  const& value)
+{
+    stat->stringCount++;
+    stat->stringLength += value.size();
+}
+
+
+template<typename V>
+inline void getStats(Stat* stat, std::map<std::string, V> const& value)
+{
+    stat->objectCount++;
+    stat->memberCount += value.size();
+    for(auto const& da: value) {
+        getStats(stat, da.first);
+        getStats(stat, da.second);
+    }
+}
+
+template<typename V>
+inline void getStats(Stat* stat, std::vector<V> const& value)
+{
+    stat->arrayCount++;
+    stat->elementCount += value.size();
+    for(auto const& da: value) {
+        getStats(stat, da);
+    }
+}
+
+
+#endif

--- a/src/tests/ThorsSerializer_StringNumber.h
+++ b/src/tests/ThorsSerializer_StringNumber.h
@@ -1,0 +1,28 @@
+#ifndef THORS_SERIALIZER_EXACT_DOUBLE_H
+#define THORS_SERIALIZER_EXACT_DOUBLE_H
+
+#include "ThorSerialize/Traits.h"
+#include "ThorSerialize/SerUtil.h"
+#include <iostream>
+#include <string>
+#include <cctype>
+
+class StringNumber
+{
+    std::string     data;
+    friend std::ostream& operator<<(std::ostream& str, StringNumber const& val)
+    {
+        return str << val.data;
+    }
+    friend std::istream& operator>>(std::istream& str, StringNumber& val)
+    {
+        return std::getline(str, val.data);
+    }
+};
+ThorsAnvil_MakeTraitCustom(StringNumber);
+inline void getStats(Stat* stat, StringNumber const&)
+{
+    stat->numberCount++;
+}
+
+#endif

--- a/src/tests/ThorsSerializer_Twitter.h
+++ b/src/tests/ThorsSerializer_Twitter.h
@@ -1,0 +1,440 @@
+#ifndef THORS_SERIALIZER_TWITTER_H
+#define THORS_SERIALIZER_TWITTER_H
+
+#include "ThorSerialize/Traits.h"
+#include "ThorSerialize/SerUtil.h"
+#include <iostream>
+#include <map>
+#include <vector>
+#include <string>
+#include <memory>
+
+using IntVec = std::vector<int>;
+
+template<typename T>
+using Opt       = std::unique_ptr<T>;
+using Symbol    = std::map<std::string, std::string>;
+using Symbols   = std::vector<Symbol>;
+
+struct Metadata
+{
+    std::string         result_type;
+    std::string         iso_language_code;
+};
+ThorsAnvil_MakeTrait(Metadata, result_type, iso_language_code);
+inline void getStats(Stat* stat, Metadata const& value)
+{
+    stat->objectCount++;
+    stat->memberCount += 2;
+    stat->stringCount += 4; /* Key, Key, Value, Value */
+    stat->stringLength += (11 /*result_type*/ + 17 /*iso_language_code*/ + value.result_type.size() + value.iso_language_code.size());
+}
+
+struct URL
+{
+    std::string         url;
+    std::string         expanded_url;
+    std::string         display_url;
+    IntVec              indices;
+};
+ThorsAnvil_MakeTrait(URL, url, expanded_url, display_url, indices);
+inline void getStats(Stat* stat, URL const& value)
+{
+    stat->objectCount++;
+    stat->memberCount += 4;
+    stat->stringCount += 7; /* Key, Key, Key, Key, Value, Value, Value */
+    stat->stringLength += (3 /*url*/ + 12 /*expanded_url*/ + 11 /*display_url*/ + 7 /*indices*/
+                        + value.url.size() + value.expanded_url.size() + value.display_url.size());
+    getStats(stat, value.indices);
+}
+using URLS = std::vector<URL>;
+
+struct URLObject
+{
+    URLS                urls;
+};
+ThorsAnvil_MakeTrait(URLObject, urls);
+inline void getStats(Stat* stat, URLObject const& value)
+{
+    stat->objectCount++;
+    stat->memberCount += 1;
+    stat->stringCount += 1;
+    stat->stringLength += (4 /*urls*/);
+
+    getStats(stat, value.urls);
+}
+
+struct Entities
+{
+    Opt<URLObject>      url;
+    URLObject           description;
+};
+ThorsAnvil_MakeTrait(Entities, url, description);
+inline void getStats(Stat* stat, Entities const& value)
+{
+    stat->objectCount++;
+    stat->memberCount += 1;
+    stat->stringCount += 1;
+    stat->stringLength += 11 /*description*/;
+    getStats(stat, value.description);
+
+    getStatsMayNotExist(stat, value.url, 3 /*url*/);
+}
+
+struct User
+{
+    long                id;
+    std::string         id_str;
+    std::string         name;
+    std::string         screen_name;
+    std::string         location;
+    std::string         description;
+    Opt<std::string>    url;
+    Entities            entities;
+    int                 followers_count;
+    int                 friends_count;
+    int                 listed_count;
+    std::string         created_at;
+    int                 favourites_count;
+    Opt<int>            utc_offset;
+    Opt<std::string>    time_zone;
+    bool                geo_enabled;
+    bool                verified;
+    int                 statuses_count;
+    std::string         lang;
+    bool                contributors_enabled;
+    bool                is_translator;
+    bool                is_translation_enabled;
+    std::string         profile_background_color;
+    std::string         profile_background_image_url;
+    std::string         profile_background_image_url_https;
+    bool                profile_background_tile;
+    std::string         profile_image_url;
+    std::string         profile_image_url_https;
+    Opt<std::string>    profile_banner_url;
+    std::string         profile_link_color;
+    std::string         profile_sidebar_border_color;
+    std::string         profile_sidebar_fill_color;
+    std::string         profile_text_color;
+    bool                profile_use_background_image;
+    bool                default_profile;
+    bool                default_profile_image;
+    bool                following;
+    bool                follow_request_sent;
+    bool                notifications;
+};
+ThorsAnvil_MakeTrait(User, id, id_str, name, screen_name, location, description, url, entities, followers_count, friends_count, listed_count, created_at, favourites_count, utc_offset, time_zone, geo_enabled, verified, statuses_count, lang, contributors_enabled, is_translator, is_translation_enabled, profile_background_color, profile_background_image_url, profile_background_image_url_https, profile_background_tile, profile_image_url, profile_image_url_https, profile_banner_url, profile_link_color, profile_sidebar_border_color, profile_sidebar_fill_color, profile_text_color, profile_use_background_image, default_profile, default_profile_image, following, follow_request_sent, notifications);
+inline void getStats(Stat* stat, User const& value)
+{
+    stat->objectCount++;
+    stat->memberCount += 39;
+    stat->stringCount += 39;
+    stat->stringLength += (2 /*id*/ + 6 /*id_str*/ + 4 /*name*/ + 11 /*screen_name*/ + 8 /*location*/ + 11 /*description*/
+                        + 3 /*url*/ + 8 /*entities*/ + 9 /*protected*/ + 15 /*followers_count*/ + 13 /*friends_count*/ + 12 /*listed_count*/
+                        + 10 /*created_at*/ + 16 /*favourites_count*/ + 10 /*utc_offset*/ + 9 /*time_zone*/
+                        + 11 /*geo_enabled*/ + 8 /*verified*/ + 14 /*statuses_count*/ + 4 /*lang*/ + 20 /*contributors_enabled*/
+                        + 13 /*is_translator*/ + 22 /*is_translation_enabled*/ + 24 /*profile_background_color*/
+                        + 28 /*profile_background_image_url*/ + 34 /*profile_background_image_url_https*/
+                        + 23 /*profile_background_tile*/ + 17 /*profile_image_url*/ + 23 /*profile_image_url_https*/
+                        + 18 /*profile_link_color*/ + 28 /*profile_sidebar_border_color*/
+                        + 26 /*profile_sidebar_fill_color*/ + 18 /*profile_text_color*/ + 28 /*profile_use_background_image*/
+                        + 15 /*default_profile*/ + 21 /*default_profile_image*/ + 9 /*following*/
+                        + 19 /*follow_request_sent*/ + 13 /*notifications*/);
+
+    getStats(stat, value.id);
+    getStats(stat, value.id_str);
+    getStats(stat, value.name);
+    getStats(stat, value.screen_name);
+    getStats(stat, value.location);
+    getStats(stat, value.description);
+    getStats(stat, value.url);
+    getStats(stat, value.entities);
+    getStats(stat, false); /*protected*/
+    getStats(stat, value.followers_count);
+    getStats(stat, value.friends_count);
+    getStats(stat, value.listed_count);
+    getStats(stat, value.created_at);
+    getStats(stat, value.favourites_count);
+    getStats(stat, value.utc_offset);
+    getStats(stat, value.time_zone);
+    getStats(stat, value.geo_enabled);
+    getStats(stat, value.verified);
+    getStats(stat, value.statuses_count);
+    getStats(stat, value.lang);
+    getStats(stat, value.contributors_enabled);
+    getStats(stat, value.is_translator);
+    getStats(stat, value.is_translation_enabled);
+    getStats(stat, value.profile_background_color);
+    getStats(stat, value.profile_background_image_url);
+    getStats(stat, value.profile_background_image_url_https);
+    getStats(stat, value.profile_background_tile);
+    getStats(stat, value.profile_image_url);
+    getStats(stat, value.profile_image_url_https);
+    getStatsMayNotExist(stat, value.profile_banner_url, 18 /*profile_banner_url*/);
+    getStats(stat, value.profile_link_color);
+    getStats(stat, value.profile_sidebar_border_color);
+    getStats(stat, value.profile_sidebar_fill_color);
+    getStats(stat, value.profile_text_color);
+    getStats(stat, value.profile_use_background_image);
+    getStats(stat, value.default_profile);
+    getStats(stat, value.default_profile_image);
+    getStats(stat, value.following);
+    getStats(stat, value.follow_request_sent);
+    getStats(stat, value.notifications);
+}
+using Users = std::vector<User>;
+
+struct Hashtag
+{
+    std::string         text;
+    IntVec              indices;
+};
+ThorsAnvil_MakeTrait(Hashtag, text, indices);
+inline void getStats(Stat* stat, Hashtag const& value)
+{
+    stat->objectCount++;
+    stat->memberCount += 2;
+    stat->stringCount += 3;
+    stat->stringLength += (4 /*text*/ + 7 /*indices*/ + value.text.size());
+    getStats(stat, value.indices);
+}
+using Hashtags = std::vector<Hashtag>;
+
+struct UserMention
+{
+    std::string         screen_name;
+    std::string         name;
+    long                id;
+    std::string         id_str;
+    IntVec              indices;
+};
+ThorsAnvil_MakeTrait(UserMention, screen_name, name, id, id_str, indices);
+inline void getStats(Stat* stat, UserMention const& value)
+{
+    stat->objectCount++;
+    stat->memberCount += 5;
+    stat->stringCount += 8; /*5 Keys + 3 values*/
+    stat->stringLength += (11 /*screen_name*/ + 4 /*name*/ + 2 /*id*/ + 6 /*id_str*/ + 7 /*indices*/
+                        + value.screen_name.size() + value.name.size() + value.id_str.size());
+    stat->numberCount++;
+    getStats(stat, value.indices);
+}
+using UserMentions = std::vector<UserMention>;
+
+struct Size
+{
+    int                 w;
+    int                 h;
+    std::string         resize;
+};
+ThorsAnvil_MakeTrait(Size, w, h, resize);
+inline void getStats(Stat* stat, Size const& value)
+{
+    stat->objectCount++;
+    stat->memberCount += 3;
+    stat->stringCount += 4; /* 3 Keys 1 Value */
+    stat->stringLength += ( 1 /*w*/ + 1 /*h*/ + 6 /*resize*/
+                            +value.resize.size());
+    stat->numberCount += 2;
+}
+
+struct Sizes
+{
+    Size                medium;
+    Size                small;
+    Size                thumb;
+    Size                large;
+};
+ThorsAnvil_MakeTrait(Sizes, medium, small, thumb, large);
+inline void getStats(Stat* stat, Sizes const& value)
+{
+    stat->objectCount++;
+    stat->memberCount += 4;
+    stat->stringCount += 4;
+    stat->stringLength += (6 /*medium*/ + 5 /*small*/ + 5 /*thumb*/ + 5 /*large*/);
+    getStats(stat, value.medium);
+    getStats(stat, value.small);
+    getStats(stat, value.thumb);
+    getStats(stat, value.large);
+}
+
+struct Media
+{
+    long                id;
+    std::string         id_str;
+    IntVec              indices;
+    std::string         media_url;
+    std::string         media_url_https;
+    std::string         url;
+    std::string         display_url;
+    std::string         expanded_url;
+    std::string         type;
+    Sizes               sizes;
+    Opt<long>           source_status_id;
+    Opt<std::string>    source_status_id_str;
+};
+ThorsAnvil_MakeTrait(Media, id, id_str, indices, media_url, media_url_https, url, display_url, expanded_url, type, sizes, source_status_id, source_status_id_str);
+inline void getStats(Stat* stat, Media const& value)
+{
+    stat->objectCount++;
+    stat->memberCount += 10;
+    stat->stringCount += 10;
+    stat->stringLength += (2 /*id*/ + 6 /*id_str*/ + 7 /*indices*/ + 9 /*media_url*/ + 15 /*media_url_https*/ + 3 /*url*/
+                        + 11 /*display_url*/ + 12 /*expanded_url*/ + 4 /*type*/ + 5 /*sizes*/);
+
+    getStats(stat, value.id);
+    getStats(stat, value.id_str);
+    getStats(stat, value.indices);
+    getStats(stat, value.media_url);
+    getStats(stat, value.media_url_https);
+    getStats(stat, value.url);
+    getStats(stat, value.display_url);
+    getStats(stat, value.expanded_url);
+    getStats(stat, value.type);
+    getStats(stat, value.sizes);
+    getStatsMayNotExist(stat, value.source_status_id, 16 /*source_status_id*/);
+    getStatsMayNotExist(stat, value.source_status_id_str, 20 /*source_status_id_str*/);
+}
+using Medias = std::vector<Media>;
+
+struct TwitEntities
+{
+    Hashtags            hashtags;
+    Symbols             symbols;
+    URLS                urls;
+    UserMentions        user_mentions;
+    Opt<Medias>         media;
+};
+ThorsAnvil_MakeTrait(TwitEntities, hashtags, symbols, urls, user_mentions, media);
+inline void getStats(Stat* stat, TwitEntities const& value)
+{
+    stat->objectCount++;
+    stat->memberCount += 4;
+    stat->stringCount += 4;
+    stat->stringLength += (8 /*hashtags*/ + 7 /*symbols*/ + 4 /*urls*/ + 13 /*user_mentions*/);
+    getStats(stat, value.hashtags);
+    getStats(stat, value.symbols);
+    getStats(stat, value.urls);
+    getStats(stat, value.user_mentions);
+    getStatsMayNotExist(stat, value.media, 5 /*media*/);
+}
+
+struct BaseStatus
+{
+    Metadata            metadata;
+    std::string         created_at;
+    long                id;
+    std::string         id_str;
+    std::string         text;
+    std::string         source;
+    bool                truncated;
+    Opt<long>           in_reply_to_status_id;
+    Opt<std::string>    in_reply_to_status_id_str;
+    Opt<long>           in_reply_to_user_id;
+    Opt<std::string>    in_reply_to_user_id_str;
+    Opt<std::string>    in_reply_to_screen_name;
+    User                user;
+    Opt<int>            geo;
+    Opt<int>            coordinates;
+    Opt<int>            place;
+    Opt<int>            contributors;
+    int                 retweet_count;
+    int                 favorite_count;
+    TwitEntities        entities;
+    bool                favorited;
+    bool                retweeted;
+    Opt<bool>           possibly_sensitive;
+    std::string         lang;
+};
+ThorsAnvil_MakeTrait(BaseStatus, metadata, created_at, id, id_str, text, source, truncated, in_reply_to_status_id, in_reply_to_status_id_str, in_reply_to_user_id, in_reply_to_user_id_str, in_reply_to_screen_name, user, geo, coordinates, place, contributors, retweet_count, favorite_count, entities, favorited, retweeted, possibly_sensitive, lang);
+inline void getStats(Stat* stat, BaseStatus const& value)
+{
+    stat->objectCount++;
+    stat->memberCount += 23;
+    stat->stringCount += 23;
+    stat->stringLength += (8 /*metadata*/ + 10 /*created_at*/ + 2 /*id*/ + 6 /*id_str*/ + 4 /*text*/ + 6 /*source*/
+                            + 9 /*truncated*/ + 21 /*in_reply_to_status_id*/ + 25 /*in_reply_to_status_id_str*/
+                            + 19 /*in_reply_to_user_id*/ + 23 /*in_reply_to_user_id_str*/ + 23 /*in_reply_to_screen_name*/
+                            + 4 /*user*/ + 3 /*geo*/ + 11 /*coordinates*/ + 5 /*place*/ + 12 /*contributors*/
+                            + 13 /*retweet_count*/ + 14 /*favorite_count*/ + 8 /*entities*/ + 9 /*favorited*/
+                            + 9 /*retweeted*/ + 4 /*lang*/);
+
+    getStats(stat, value.metadata);
+    getStats(stat, value.created_at);
+    getStats(stat, value.id);
+    getStats(stat, value.id_str);
+    getStats(stat, value.text);
+    getStats(stat, value.source);
+    getStats(stat, value.truncated);
+    getStats(stat, value.in_reply_to_status_id);
+    getStats(stat, value.in_reply_to_status_id_str);
+    getStats(stat, value.in_reply_to_user_id);
+    getStats(stat, value.in_reply_to_user_id_str);
+    getStats(stat, value.in_reply_to_screen_name);
+    getStats(stat, value.user);
+    getStats(stat, value.geo);
+    getStats(stat, value.coordinates);
+    getStats(stat, value.place);
+    getStats(stat, value.contributors);
+    getStats(stat, value.retweet_count);
+    getStats(stat, value.favorite_count);
+    getStats(stat, value.entities);
+    getStats(stat, value.favorited);
+    getStats(stat, value.retweeted);
+    getStatsMayNotExist(stat, value.possibly_sensitive, 18 /*possibly_sensitive*/);
+    getStats(stat, value.lang);
+}
+
+struct MainStatus: public BaseStatus
+{
+    Opt<BaseStatus>     retweeted_status;
+};
+ThorsAnvil_ExpandTrait(BaseStatus, MainStatus, retweeted_status);
+inline void getStats(Stat* stat, MainStatus const& value)
+{
+    getStats(stat, static_cast<BaseStatus const&>(value));
+    getStatsMayNotExist(stat, value.retweeted_status, 16 /*retweeted_status*/);
+}
+using Statuses = std::vector<MainStatus>;
+
+struct SearchMetadata
+{
+    double              completed_in;
+    long                max_id;
+    std::string         max_id_str;
+    std::string         next_results;
+    std::string         query;
+    std::string         refresh_url;
+    int                 count;
+    long                since_id;
+    std::string         since_id_str;
+};
+ThorsAnvil_MakeTrait(SearchMetadata, completed_in, max_id, max_id_str, next_results, query, refresh_url, count, since_id, since_id_str);
+inline void getStats(Stat* stat, SearchMetadata const& value)
+{
+    stat->objectCount++;
+    stat->memberCount += 9;
+    stat->stringCount += (9 + 5);
+    stat->stringLength += (12 /*completed_in*/ + 6 /*max_id*/ + 10 /*max_id_str*/ + 12 /*next_results*/
+                            + 5 /*query*/ + 11 /*refresh_url*/ + 5 /*count*/ + 8 /*since_id*/
+                            + 12 /*since_id_str*/ + value.max_id_str.size() + value.next_results.size()
+                            + value.query.size() + value.refresh_url.size() + value.since_id_str.size());
+    stat->numberCount += 4;
+}
+
+struct Twitter
+{
+    Statuses            statuses;
+    SearchMetadata      search_metadata;
+};
+ThorsAnvil_MakeTrait(Twitter, statuses, search_metadata);
+inline void getStats(Stat* stat, Twitter const& value)
+{
+    stat->objectCount++;
+    stat->memberCount += 2;
+    stat->stringCount += 2;
+    stat->stringLength += (8 /*statuses*/ + 15 /*search_metadata*/);
+    getStats(stat, value.statuses);
+    getStats(stat, value.search_metadata);
+}
+#endif

--- a/src/tests/ThorsSerializer_citm_catalog.h
+++ b/src/tests/ThorsSerializer_citm_catalog.h
@@ -1,0 +1,176 @@
+#ifndef THORS_SERIALIZER_CITM_CATALOG_H
+#define THORS_SERIALIZER_CITM_CATALOG_H
+
+#include "ThorSerialize/Traits.h"
+#include "ThorSerialize/SerUtil.h"
+#include <iostream>
+#include <map>
+#include <memory>
+#include <vector>
+#include <string>
+
+template<typename T>
+using Opt = std::unique_ptr<T>;
+
+using IntVec   = std::vector<int>;
+struct Event
+{
+    Opt<int>            description;
+    long                id;
+    Opt<std::string>    logo;
+    std::string         name;
+    IntVec              subTopicIds;
+    Opt<int>            subjectCode;
+    Opt<int>            subtitle;
+    IntVec              topicIds;
+};
+ThorsAnvil_MakeTrait(Event, description, id, logo, name, subTopicIds, subjectCode, subtitle, topicIds);
+inline void getStats(Stat* stat, Event const& value)
+{
+    stat->objectCount++;
+    stat->memberCount += 8;
+    stat->stringCount += 8 + 1;
+    stat->numberCount++;
+    (value.description ? stat->numberCount : stat->nullCount)++;
+    (value.logo ? stat->stringCount : stat->nullCount)++;
+    (value.subjectCode ? stat->numberCount : stat->nullCount)++;
+    (value.subtitle ? stat->numberCount : stat->nullCount)++;
+    stat->stringLength += (11 /*description*/ + 2 /*id*/ + 4 /*logo*/ + 4 /*name*/ + 11 /*subTopicIds*/
+                            + 11 /*subjectCode*/ + 8 /*subtitle*/ + 8 + /*topicIds*/ + value.name.size()
+                            + (value.logo ? value.logo->size() : 0));
+    getStats(stat, value.subTopicIds);
+    getStats(stat, value.topicIds);
+}
+
+struct Price
+{
+    int                 amount;
+    int                 audienceSubCategoryId;
+    int                 seatCategoryId;
+};
+ThorsAnvil_MakeTrait(Price, amount, audienceSubCategoryId, seatCategoryId);
+inline void getStats(Stat* stat, Price const&)
+{
+    stat->objectCount++;
+    stat->memberCount += 3;
+    stat->stringCount += 3;
+    stat->numberCount += 3;
+    stat->stringLength += (6 /*amount*/ + 21 /*audienceSubCategoryId*/ + 14 /*seatCategoryId*/);
+}
+using Prices = std::vector<Price>;
+
+struct Area
+{
+    int                 areaId;
+    IntVec              blockIds;
+};
+ThorsAnvil_MakeTrait(Area, areaId, blockIds);
+inline void getStats(Stat* stat, Area const& value)
+{
+    stat->objectCount++;
+    stat->memberCount += 2;
+    stat->stringCount += 2;
+    stat->numberCount += 1;
+    stat->stringLength += (6 /*areaId*/ + 8 /*blockIds*/);
+    getStats(stat, value.blockIds);
+}
+using Areas = std::vector<Area>;
+
+struct SeatCategorie
+{
+    Areas               areas;
+    int                 seatCategoryId;
+};
+ThorsAnvil_MakeTrait(SeatCategorie, areas, seatCategoryId);
+inline void getStats(Stat* stat, SeatCategorie const& value)
+{
+    stat->objectCount++;
+    stat->memberCount += 2;
+    stat->stringCount += 2;
+    stat->stringLength += (5 /*areas*/ + 14 /*seatCategoryId*/);
+    stat->numberCount++;
+    getStats(stat, value.areas);
+}
+using SeatCategories = std::vector<SeatCategorie>;
+
+struct Performance
+{
+    int                 eventId;
+    int                 id;
+    Opt<std::string>    logo;
+    Opt<std::string>    name;
+    Prices              prices;
+    SeatCategories      seatCategories;
+    Opt<int>            seatMapImage;
+    long                start;
+    std::string         venueCode;
+};
+ThorsAnvil_MakeTrait(Performance, eventId, id, logo, name, prices, seatCategories, seatMapImage, start, venueCode);
+inline void getStats(Stat* stat, Performance const& value)
+{
+    stat->objectCount++;
+    stat->memberCount += 9;
+    stat->stringCount += 10;
+    stat->stringLength += (7 /*eventId*/ + 2 /*id*/ + 4 /*logo*/ + 4 /*name*/ + 6 /*prices*/ + 14 /*seatCategories*/
+                         + 12 /*seatMapImage*/ + 5 /*start*/ + 9 /*venueCode*/ + value.venueCode.size() 
+                         + (value.name ? value.name->size() : 0) + (value.logo ? value.logo->size() : 0));
+    stat->numberCount += 3;
+    (value.seatMapImage ? stat->numberCount : stat->nullCount)++;
+    (value.logo ? stat->stringCount : stat->nullCount)++;
+    (value.name ? stat->stringCount : stat->nullCount)++;
+    getStats(stat, value.prices);
+    getStats(stat, value.seatCategories);
+}
+using Performances = std::vector<Performance>;
+
+struct VenueNames
+{
+    std::string     PLEYEL_PLEYEL;
+};
+ThorsAnvil_MakeTrait(VenueNames, PLEYEL_PLEYEL);
+inline void getStats(Stat* stat, VenueNames const& value)
+{
+    stat->objectCount++;
+    stat->memberCount++;
+    stat->stringCount += 2;
+    stat->stringLength += (13 /*PLEYEL_PLEYEL*/ + value.PLEYEL_PLEYEL.size());
+}
+
+struct Perform
+{
+    std::map<std::string, std::string>  areaNames;
+    std::map<std::string, std::string>  audienceSubCategoryNames;
+    std::map<std::string, std::string>  blockNames;
+    std::map<std::string, Event>        events;
+    Performances                        performances;
+    std::map<std::string, std::string>  seatCategoryNames;
+    std::map<std::string, std::string>  subTopicNames;
+    std::map<std::string, std::string>  subjectNames;
+    std::map<std::string, std::string>  topicNames;
+    std::map<std::string, IntVec>       topicSubTopics;
+    VenueNames                          venueNames;
+};
+ThorsAnvil_MakeTrait(Perform, areaNames, audienceSubCategoryNames, blockNames, events, performances, seatCategoryNames, subTopicNames, subjectNames, topicNames, topicSubTopics, venueNames);
+inline void getStats(Stat* stat, Perform const& value)
+{
+    stat->objectCount++;
+    stat->memberCount += 11;
+    stat->stringCount += 11; /* All Keys */
+    stat->stringLength +=  ( 9 /*areaNames*/ + 24 /*audienceSubCategoryNames*/ + 10 /*blockNames*/
+                            + 6 /*events*/ + 12 /*performances*/ + 17 /*seatCategoryNames*/
+                            + 13 /*subTopicNames*/ + 12 /*subjectNames*/ + 10 /*topicNames*/
+                            + 14 /*topicSubTopics*/ + 10 /*venueNames*/);
+    getStats(stat, value.areaNames);
+    getStats(stat, value.audienceSubCategoryNames);
+    getStats(stat, value.blockNames);
+    getStats(stat, value.events);
+    getStats(stat, value.performances);
+    getStats(stat, value.seatCategoryNames);
+    getStats(stat, value.subTopicNames);
+    getStats(stat, value.subjectNames);
+    getStats(stat, value.topicNames);
+    getStats(stat, value.topicSubTopics);
+    getStats(stat, value.venueNames);
+}
+
+#endif


### PR DESCRIPTION
Uses C++14

Uses a declarative style to build mappings between json and C++ objects.
See: https://github.com/Loki-Astari/ThorsSerializer/blob/master/doc/example1.md

Two other Additions:

Added the "--parser=<X>" flag.
      This allows you to run only one JsonParser. This is very useful when debugging a single parser.

Modified SetUp() and TearDown()
      Original functionality remain intact. But added version that passes a name of test to SetUp() TearDown() so that you can take specific test initialization. If you don't override these methods the default action is to call the original unnamed versions thus no changes to other libraries required.

