### PR TITLE
Replace a space in a URL with %20

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ This is the total duration of prettifying 3 DOMs to JSONs, sorted in ascending o
 
 ![Code Size](sample/performance_Corei7-4980HQ@2.80GHz_mac64_clang7.0_7._Code_size_FileSize_(byte).png)
 
-The is the size of executable program, which parses a JSON from `stdin` to a DOM and then computes the statistics of the DOM. Lower is better. [Details](https://rawgit.com/miloyip/nativejson-benchmark/master/sample/performance_Corei7-4980HQ@2.80GHz_mac64_clang7.0.html#7.%20Code size)
+The is the size of executable program, which parses a JSON from `stdin` to a DOM and then computes the statistics of the DOM. Lower is better. [Details](https://rawgit.com/miloyip/nativejson-benchmark/master/sample/performance_Corei7-4980HQ@2.80GHz_mac64_clang7.0.html#7.%20Code%20size)
 
 ## FAQ
 


### PR DESCRIPTION
I checked that the replacement URL goes to exactly the same place as the URL with the space in it.

As it, the URL doesn't seem to render properly on github, as seen in https://github.com/miloyip/nativejson-benchmark/blob/master/README.md#code-size  

Thanks for a very useful benchmark!