### PR TITLE
correct the variable name in main.cpp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -275,8 +275,8 @@ static void Verify(const TestBase& test, const TestJsonList& testJsons) {
             statProblem = &stat1;
             statProblemWhich = 1;
         }
-        else if (memcmp(&stat1, &itr->stat,      sizeof(Stat)) != 0 &&
-                 memcmp(&stat1, &itr->statUTF16, sizeof(Stat)) != 0)
+        else if (memcmp(&stat2, &itr->stat,      sizeof(Stat)) != 0 &&
+                 memcmp(&stat2, &itr->statUTF16, sizeof(Stat)) != 0)
         {
             statProblem = &stat2;
             statProblemWhich = 2;


### PR DESCRIPTION
the variable name should be stat2 in line 278 & 279 in main.cpp

```C++
        Stat* statProblem = 0;
        int statProblemWhich = 0;
        if (memcmp(&stat1, &itr->stat,      sizeof(Stat)) != 0 &&
            memcmp(&stat1, &itr->statUTF16, sizeof(Stat)) != 0)
        {
            statProblem = &stat1;
            statProblemWhich = 1;
        }
        //here stat1 should be stat2
        else if (memcmp(&stat1, &itr->stat,      sizeof(Stat)) != 0 &&
                 memcmp(&stat1, &itr->statUTF16, sizeof(Stat)) != 0)
        {
            statProblem = &stat2;
            statProblemWhich = 2;
        }
```