### PR TITLE
Simdjson v0.3 Support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -125,3 +125,6 @@
 [submodule "thirdparty/facil.io"]
 	path = thirdparty/facil.io
 	url = https://github.com/boazsegev/facil.io.git
+[submodule "thirdparty/simdjson"]
+	path = thirdparty/simdjson
+	url = https://github.com/simdjson/simdjson

--- a/build/premake5.lua
+++ b/build/premake5.lua
@@ -110,7 +110,7 @@ solution "benchmark"
 
 		setTargetObjDir("../bin")
 
-		copyfiles("../thirdparty/include/yajl", "../thirdparty/yajl/src/api/*.h")
+		copyfiles("../thirdparty/include/yajl", "../thirdparty/yajl/src/api/*.h" )
 
 	project "nativejson"
 		kind "ConsoleApp"
@@ -133,6 +133,7 @@ solution "benchmark"
             "../thirdparty/ULib/include",
             "../thirdparty/facil.io/lib/facil/core/types",
             "../thirdparty/facil.io/lib/facil/core/types/fiobj",
+            "../thirdparty/simdjson/singleheader",
         }
 
       linkoptions { "../../thirdparty/ULib/src/ulib/.libs/libulib.a" }
@@ -140,10 +141,12 @@ solution "benchmark"
 		files {
 			"../src/*.h",
 			"../src/*.cpp",
-			"../src/tests/*.cpp",
+			"../src/tests/*.cpp"
 		}
 
-		libdirs { "../bin" }
+		libdirs { "../bin",
+                "../thirdparty/simdjson"  
+                }
 
 		setTargetObjDir("../bin")
 
@@ -191,6 +194,7 @@ solution "jsonstat"
         "../thirdparty/ULib/include",
         "../thirdparty/facil.io/lib/facil/core/types",
         "../thirdparty/facil.io/lib/facil/core/types/fiobj",
+        "../thirdparty/simdjson/singleheader",
     }
 
     configuration "release"
@@ -221,7 +225,7 @@ solution "jsonstat"
 
         setTargetObjDir("../bin/jsonstat")
 
-		copyfiles("../thirdparty/include/yajl", "../thirdparty/yajl/src/api/*.h")
+		copyfiles("../thirdparty/include/yajl", "../thirdparty/yajl/src/api/*.h", "../thirdparty/simdjson/src/simdjson.cpp")
 
     local testfiles = os.matchfiles("../src/tests/*.cpp")
     for _, testfile in ipairs(testfiles) do

--- a/src/tests/simdjsontest.cpp
+++ b/src/tests/simdjsontest.cpp
@@ -1,0 +1,152 @@
+#include <string>
+#include <sstream>
+#include <string_view>
+
+#include "../test.h"
+#include "simdjson.h"
+#include "simdjson.cpp"
+
+using namespace simdjson;
+
+static void GenStat(Stat& stat, const dom::element& v) {
+
+switch (v.type()) {
+    case dom::element_type::ARRAY:
+      for (dom::element child : dom::array(v)) {
+        GenStat(stat, child);
+      }
+      stat.arrayCount++; 
+      stat.elementCount += dom::array(v).size();
+      break;
+    case dom::element_type::OBJECT:
+      for (dom::key_value_pair kv : dom::object(v)) {
+       GenStat(stat, dom::element(kv.value));
+      }
+	stat.objectCount++;
+	stat.memberCount += dom::object(v).size();
+  	stat.stringCount += dom::object(v).size();
+      break;
+    case dom::element_type::INT64:
+      break;
+    case dom::element_type::UINT64:
+      break;
+    case dom::element_type::DOUBLE:
+       stat.numberCount++;
+      break;
+    case dom::element_type::STRING:
+      {stat.stringCount++;
+      std::string_view sv = v.get<std::string_view>();
+      stat.stringLength += sv.size();}
+      break;
+    case dom::element_type::BOOL:
+      if (v.get<bool>()) {
+          stat.trueCount++;
+      } else {
+          stat.falseCount++;
+      }
+      break;
+    case dom::element_type::NULL_VALUE:
+      ++stat.nullCount;
+      break;
+  }
+}
+
+class SimdJsonParseResult : public ParseResultBase {
+public:
+    dom::element root{};
+    std::unique_ptr<dom::parser> parser = std::make_unique<dom::parser>();
+};
+
+class SimdStringResult : public StringResultBase {
+public:
+    std::stringstream ss;
+    const char* c_str() const override { 
+        return ss.str().c_str();
+    }
+};
+class SimdTest : public TestBase {
+public:
+#if TEST_INFO
+    const char* GetName() const override{ return "simdjson"; }
+    const char* GetFilename() const override { return __FILE__; }
+#endif
+
+#if TEST_PARSE
+    ParseResultBase* Parse(const char* j, size_t length) const override {
+    
+        auto pr = std::make_unique<SimdJsonParseResult>();
+	
+        std::string_view s(j, length);
+        simdjson::error_code error;
+        pr->parser->parse(s).tie(pr->root, error);
+	if (error) {
+            return nullptr;
+        }
+	return pr.release();
+    }
+#endif
+
+#if TEST_STRINGIFY
+    StringResultBase* Stringify(const ParseResultBase* parseResult) const override {
+     
+        auto sr = std::make_unique<SimdStringResult>();
+
+        auto pr = static_cast<const SimdJsonParseResult*>(parseResult);
+	sr->ss << pr->root;
+        return sr.release();
+    }
+#endif
+
+#if TEST_PRETTIFY
+    //Currently unsupported, simdjson v0.3
+    StringResultBase* Prettify(const ParseResultBase* parseResult) const override{
+         (void)parseResult;
+	 return nullptr;
+    }
+#endif
+
+#if TEST_STATISTICS
+    bool Statistics(const ParseResultBase* parseResult, Stat* stat) const override {
+
+        auto pr = static_cast<const SimdJsonParseResult*>(parseResult);
+        memset(stat, 0, sizeof(Stat));
+
+        GenStat(*stat, pr->root);
+        return true;
+    }
+#endif
+
+#if TEST_CONFORMANCE
+    bool ParseDouble(const char* j, double* d) const override {
+        simdjson::error_code error;
+        simdjson::dom::parser parser;
+        parser.parse(j, std::strlen(j)).at(0).get<double>().tie(*d,error);
+	if (error) {
+            return false;
+	}        
+
+        return true;
+    }
+
+    bool ParseString(const char* j, std::string& s) const override {
+ 
+        simdjson::error_code error;
+       
+        simdjson::dom::parser parser;
+	dom::element element;
+        parser.parse(j, std::strlen(j)).tie(element, error);
+        std::stringstream ss;
+        ss << element.at(0);
+	s = ss.str();
+       
+	if (error) {
+            return false;
+	}        
+
+        return true;
+    }
+#endif
+};
+
+REGISTER_TEST(SimdTest);
+


### PR DESCRIPTION
Added support for simdjson (#113) (https://github.com/simdjson/simdjson) 
Currently it does not support the SAX/ prettify tests as far as I am aware, so these have been excluded.

(Also the current build appears to be broken - I was using the workarounds in https://github.com/mloskot/nativejson-benchmark/tree/ml/issue-102-add-workarounds-to-build after which this PR will compile)

Results (on a i7 8550U) with rapidjson for comparison:

**Benchmarking Performance of simdjson** 

Parse canada.json               ...  3.974 ms      540.204 MB/s
Parse citm_catalog.json         ...  1.039 ms      1585.361 MB/s
Parse twitter.json              ...  0.441 ms      1365.666 MB/s
Stringify canada.json           ... 69.225 ms      31.011 MB/s
Stringify citm_catalog.json     ...  5.887 ms      279.801 MB/s
Stringify twitter.json          ...  7.138 ms      84.374 MB/s
Statistics canada.json          ...  1.221 ms		1758.206 MB/s
Statistics citm_catalog.json    ...  0.436 ms      3777.959 MB/s
Statistics twitter.json         ...  0.155 ms      3885.540 MB/s

**Benchmarking Performance of RapidJSON (C++)**
Parse canada.json               ...  5.153 ms      416.606 MB/s
Parse citm_catalog.json         ...  2.563 ms      642.680 MB/s
Parse twitter.json              ...  1.786 ms      337.211 MB/s
Stringify canada.json           ...  9.878 ms      217.328 MB/s
Stringify citm_catalog.json     ...  1.270 ms      1297.000 MB/s
Stringify twitter.json          ...  0.979 ms      615.177 MB/s
Statistics canada.json          ...  0.781 ms      2748.745 MB/s
Statistics citm_catalog.json    ...  0.234 ms      7039.274 MB/s
Statistics twitter.json         ...  0.092 ms      6546.290 MB/s
   
                                          