### PR TITLE
Fix for ParseString / simdjson

### DIFF
--- a/src/tests/simdjsontest.cpp
+++ b/src/tests/simdjsontest.cpp
@@ -123,13 +123,15 @@ class SimdTest : public TestBase {
 
   bool ParseString(const char *j, std::string &s) const override {
     simdjson::error_code error;
-    dom::element element;
-    simdjson::dom::parser parser;
-    parser.parse(j, std::strlen(j)).tie(element, error);;
+    std::string_view answer;
+    parser.parse(j,strlen(j))
+        .at(0)
+        .get<std::string_view>()
+        .tie(answer, error);
     if (error) {
       return false;
     }
-    s = element;
+    s = answer;
     return true;
   }
 #endif

--- a/src/tests/simdjsontest.cpp
+++ b/src/tests/simdjsontest.cpp
@@ -131,7 +131,7 @@ class SimdTest : public TestBase {
     if (error) {
       return false;
     }
-    s = answer;
+    s.assign(answer.data(), answer.size());
     return true;
   }
 #endif


### PR DESCRIPTION
The original ParseString  function in the simdjson code by @Mark407 would just grab the document and reserialize it. My fix would take the original document assume it was a string. Of course, the original documents are *arrays* containing a string. This new code should be more correct.